### PR TITLE
Source rc_file before estimating parasitics

### DIFF
--- a/scripts/evaluation.tcl
+++ b/scripts/evaluation.tcl
@@ -80,6 +80,7 @@ if {[catch { global_route -allow_congestion -congestion_report_file $crfile } gr
   }
 }
 
+source $rc_file
 # Estimate parasitics using global routing
 estimate_parasitics -global_routing
 


### PR DESCRIPTION
The current script doesn't set wire parasitic parameters, resulting in incorrect evaluation results.